### PR TITLE
Check if bigWig/bigBed file handle is still open, before reading/writ…

### DIFF
--- a/pyBigWig.c
+++ b/pyBigWig.c
@@ -197,6 +197,11 @@ static PyObject *pyBwClose(pyBigWigFile_t *self, PyObject *args) {
 //Accessor for the header (version, nLevels, nBasesCovered, minVal, maxVal, sumData, sumSquared
 static PyObject *pyBwGetHeader(pyBigWigFile_t *self, PyObject *args) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
     PyObject *ret, *val;
 
     ret = PyDict_New();
@@ -233,8 +238,14 @@ error :
 
 //Accessor for the chroms, args is optional
 static PyObject *pyBwGetChroms(pyBigWigFile_t *self, PyObject *args) {
-    PyObject *ret = NULL, *val;
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
+    PyObject *ret = NULL, *val;
+
     char *chrom = NULL;
     uint32_t i;
 
@@ -282,6 +293,11 @@ enum bwStatsType char2enum(char *s) {
 //Fetch summary statistics, default is the mean of the entire chromosome.
 static PyObject *pyBwGetStats(pyBigWigFile_t *self, PyObject *args, PyObject *kwds) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
     double *val;
     uint32_t start, end = -1, tid;
     unsigned long startl = 0, endl = -1;
@@ -356,6 +372,11 @@ static PyObject *pyBwGetValues(pyBigWigFile_t *self, PyObject *args, PyObject *k
 static PyObject *pyBwGetValues(pyBigWigFile_t *self, PyObject *args) {
 #endif
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
     int i;
     uint32_t start, end = -1, tid;
     unsigned long startl, endl;
@@ -422,6 +443,11 @@ static PyObject *pyBwGetValues(pyBigWigFile_t *self, PyObject *args) {
 
 static PyObject *pyBwGetIntervals(pyBigWigFile_t *self, PyObject *args, PyObject *kwds) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
     uint32_t start, end = -1, tid, i;
     unsigned long startl = 0, endl = -1;
     static char *kwd_list[] = {"chrom", "start", "end", NULL};
@@ -524,6 +550,11 @@ uint32_t Numeric2Uint(PyObject *obj) {
 //This runs bwCreateHdr, bwCreateChromList, and bwWriteHdr
 PyObject *pyBwAddHeader(pyBigWigFile_t *self, PyObject *args, PyObject *kwds) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
     char **chroms = NULL;
     int64_t n;
     uint32_t *lengths = NULL, len;
@@ -820,6 +851,11 @@ int getType(PyObject *chroms, PyObject *starts, PyObject *ends, PyObject *values
 //1: Can use a bwAppend* function. 0: must use a bwAdd* function
 int canAppend(pyBigWigFile_t *self, int desiredType, PyObject *chroms, PyObject *starts, PyObject *span, PyObject *step) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 0;
+    }
+
     Py_ssize_t i, sz = 0;
     uint32_t tid, uspan, ustep, ustart;
     PyObject *tmp;
@@ -906,6 +942,11 @@ int canAppend(pyBigWigFile_t *self, int desiredType, PyObject *chroms, PyObject 
 //Returns 0 on success, 1 on error. Sets self->lastTid && self->lastStart (unless there was an error)
 int PyAddIntervals(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, PyObject *ends, PyObject *values) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 1;
+    }
+
     Py_ssize_t i, sz = 0;
     char **cchroms = NULL;
     uint32_t n, *ustarts = NULL, *uends = NULL;
@@ -985,6 +1026,11 @@ error:
 //Returns 0 on success, 1 on error. Update self->lastStart
 int PyAppendIntervals(pyBigWigFile_t *self, PyObject *starts, PyObject *ends, PyObject *values) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 1;
+    }
+
     Py_ssize_t i, sz = 0;
     uint32_t n, *ustarts = NULL, *uends = NULL;
     float *fvalues = NULL;
@@ -1045,6 +1091,11 @@ error:
 //Returns 0 on success, 1 on error. Sets self->lastTid/lastStart/lastSpan (unless there was an error)
 int PyAddIntervalSpans(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, PyObject *values, PyObject *span) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 1;
+    }
+
     Py_ssize_t i, sz = 0;
     char *cchroms = NULL;
     uint32_t n, *ustarts = NULL, uspan;
@@ -1110,6 +1161,11 @@ error:
 //Returns 0 on success, 1 on error. Updates self->lastStart
 int PyAppendIntervalSpans(pyBigWigFile_t *self, PyObject *starts, PyObject *values) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 1;
+    }
+
     Py_ssize_t i, sz = 0;
     uint32_t n, *ustarts = NULL;
     float *fvalues = NULL;
@@ -1168,6 +1224,11 @@ error:
 //Returns 0 on success, 1 on error. Sets self->lastTid/self->lastSpan/lastStep/lastStart (unless there was an error)
 int PyAddIntervalSpanSteps(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, PyObject *values, PyObject *span, PyObject *step) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 1;
+    }
+
     Py_ssize_t i, sz = 0;
     char *cchrom = NULL;
     uint32_t n, ustarts, uspan, ustep;
@@ -1217,6 +1278,11 @@ error:
 //Returns 0 on success, 1 on error. Sets self->lastStart
 int PyAppendIntervalSpanSteps(pyBigWigFile_t *self, PyObject *values) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 1;
+    }
+
     Py_ssize_t i, sz = 0;
     uint32_t n;
     float *fvalues = NULL;
@@ -1256,6 +1322,12 @@ error:
 //Checks and ensures that (A) the entries are sorted correctly and don't overlap and (B) that the come after things that have already been added.
 //Returns 1 on correct input, 0 on incorrect input
 int addEntriesInputOK(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, PyObject *ends, PyObject *span, PyObject *step, int type) {
+    bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return 0;
+    }
+
     uint32_t lastTid = self->lastTid;
     uint32_t lastEnd = self->lastStart;
     uint32_t cTid, ustart, uend, uspan, ustep;
@@ -1276,12 +1348,12 @@ int addEntriesInputOK(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, 
 #ifdef WITHNUMPY
             if(PyArray_Check(chroms)) {
                 tmpStr = getNumpyStr((PyArrayObject*)chroms, i);
-                cTid = bwGetTid(self->bw, tmpStr);
+                cTid = bwGetTid(bw, tmpStr);
                 free(tmpStr);
             } else {
 #endif
                 tmp = PyList_GetItem(chroms, i);
-                cTid = bwGetTid(self->bw, PyString_AsString(tmp));
+                cTid = bwGetTid(bw, PyString_AsString(tmp));
 #ifdef WITHNUMPY
             }
 #endif
@@ -1335,7 +1407,7 @@ int addEntriesInputOK(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, 
         if(PyErr_Occurred()) return 0;
         if(uspan < 1) return 0;
         if(sz == 0) return 0;
-        cTid = bwGetTid(self->bw, PyString_AsString(chroms));
+        cTid = bwGetTid(bw, PyString_AsString(chroms));
         if(cTid == (uint32_t) -1) return 0;
         if(lastTid != (uint32_t) -1) {
             if(lastTid > cTid) return 0;
@@ -1362,7 +1434,7 @@ int addEntriesInputOK(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, 
         return 1;
     } else if(type == 2) {
         //The chrom and start need to be appropriate
-        cTid = bwGetTid(self->bw, PyString_AsString(chroms));
+        cTid = bwGetTid(bw, PyString_AsString(chroms));
         if(cTid == (uint32_t) -1) return 0;
         ustart = Numeric2Uint(starts);
         if(PyErr_Occurred()) return 0;
@@ -1384,6 +1456,12 @@ int addEntriesInputOK(pyBigWigFile_t *self, PyObject *chroms, PyObject *starts, 
 }
 
 PyObject *pyBwAddEntries(pyBigWigFile_t *self, PyObject *args, PyObject *kwds) {
+    bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
     static char *kwd_list[] = {"chroms", "starts", "ends", "values", "span", "step", "validate", NULL};
     PyObject *chroms = NULL, *starts = NULL, *ends = NULL, *values = NULL, *span = NULL, *step = NULL;
     PyObject *validate = Py_True;
@@ -1451,6 +1529,11 @@ error:
 
 static PyObject *pyBBGetEntries(pyBigWigFile_t *self, PyObject *args, PyObject *kwds) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigBed file handle is not open.");
+        return NULL;
+    }
+
     uint32_t i;
     uint32_t start, end = -1, tid;
     unsigned long startl, endl;
@@ -1521,6 +1604,11 @@ error:
 
 static PyObject *pyBBGetSQL(pyBigWigFile_t *self, PyObject *args) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigBed file handle is not open.");
+        return NULL;
+    }
+
     char *str = bbGetSQL(bw);
     size_t len = 0;
     PyObject *o = NULL;
@@ -1543,6 +1631,11 @@ static PyObject *pyBBGetSQL(pyBigWigFile_t *self, PyObject *args) {
 
 static PyObject *pyIsBigWig(pyBigWigFile_t *self, PyObject *args) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
     if(bw->type == 0) {
         Py_INCREF(Py_True);
         return Py_True;
@@ -1554,6 +1647,11 @@ static PyObject *pyIsBigWig(pyBigWigFile_t *self, PyObject *args) {
 
 static PyObject *pyIsBigBed(pyBigWigFile_t *self, PyObject *args) {
     bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigBed file handle is not open.");
+        return NULL;
+    }
+
     if(bw->type == 1) {
         Py_INCREF(Py_True);
         return Py_True;

--- a/pyBigWig.c
+++ b/pyBigWig.c
@@ -194,6 +194,17 @@ static PyObject *pyBwClose(pyBigWigFile_t *self, PyObject *args) {
     return Py_None;
 }
 
+static PyObject *pyBwEnter(pyBigWigFile_t *self, PyObject *args) {
+    bigWigFile_t *bw = self->bw;
+    if(!bw) {
+        PyErr_SetString(PyExc_RuntimeError, "bigWig file handle is not open.");
+        return NULL;
+    }
+
+    Py_INCREF(self);
+    return (PyObject*) self;
+}
+
 //Accessor for the header (version, nLevels, nBasesCovered, minVal, maxVal, sumData, sumSquared
 static PyObject *pyBwGetHeader(pyBigWigFile_t *self, PyObject *args) {
     bigWigFile_t *bw = self->bw;

--- a/pyBigWig.h
+++ b/pyBigWig.h
@@ -13,6 +13,7 @@ typedef struct {
 } pyBigWigFile_t;
 
 static PyObject *pyBwOpen(PyObject *self, PyObject *pyFname);
+static PyObject *pyBwEnter(pyBigWigFile_t *pybw, PyObject *args);
 static PyObject *pyBwClose(pyBigWigFile_t *pybw, PyObject *args);
 static PyObject *pyBwGetChroms(pyBigWigFile_t *pybw, PyObject *args);
 static PyObject *pyIsBigWig(pyBigWigFile_t *pybw, PyObject *args);
@@ -375,6 +376,8 @@ Keyword arguments:\n\
 >>> bw.addEntries([\"1\", \"1\", \"1\"], [0, 100, 125], ends=[5, 120, 126], values=[0.0, 1.0, 200.0], validate=False)\n\
 >>> bw.close()\n\
 >>> os.remove(oname)"},
+    {"__enter__", (PyCFunction)pyBwEnter, METH_NOARGS, NULL},
+    {"__exit__", (PyCFunction)pyBwClose, METH_VARARGS, NULL},
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
…ing.

Check if bigWig/bigBed file handle is still open, before trying to
read or write data from the bigWig or bigBed file.

This prevents segfaults when the bigWig object is used after it was closed.

    >>> import pyBigWig
    >>> bb = pyBigWig.open('test.bw')
    >>> bb.header()
    {'maxVal': 2L,
     'minVal': 1L,
     'nBasesCovered': 15560789L,
     'nLevels': 6L,
     'sumData': 15611000L,
     'sumSquared': 15711422L,
     'version': 4L}
    >>> bb.close()
    >>> bb.header()
    Segmentation fault (core dumped)

After this patch, the call to functions that require an open bigWig object,
return something like this:

    >>> bb.header()
    RuntimeError: bigWig file handle is not open.